### PR TITLE
Adds MD5 and SHA256 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-hex = "0.4.3"
-hex-literal = "0.4.1"
 md-5 = "0.10.6"
 sha2 = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hash_gen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5.27", features = ["derive"] }
+hex = "0.4.3"
+hex-literal = "0.4.1"
+md-5 = "0.10.6"
+sha2 = "0.10.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,71 @@
+use clap::Parser;
+use md5::{Digest, Md5};
+use sha2::Sha256;
+use std::fs::File;
+use std::io::{self, Read};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    fpath: String,
+}
+
+fn open_file(path: &String) -> Result<File, std::io::Error> {
+    let file: File = File::open(path)?; // Try to open the file
+    Ok(file) // If successful, return the file
+}
+
+fn generate_md5(file: &mut File) -> io::Result<String> {
+    let mut hasher = Md5::new();
+    let mut buffer = [0u8; 1024];
+
+    while let Ok(byte_read) = file.read(&mut buffer) {
+        if byte_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..byte_read]);
+    }
+
+    let result = hasher.finalize();
+    Ok(format!("{:x}", result))
+}
+
+fn generate_sha256(file: &mut File) -> io::Result<String> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 1024];
+
+    while let Ok(byte_read) = file.read(&mut buffer) {
+        if byte_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..byte_read]);
+    }
+
+    let result = hasher.finalize();
+    Ok(format!("{:x}", result))
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("File Name: {}", args.fpath);
+    let mut file = match open_file(&args.fpath) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("Failed to open file: {}", e);
+            return;
+        }
+    };
+
+    let md5 = generate_md5(&mut file);
+    match md5 {
+        Ok(hash) => println!("MD5 Hash is: {}", hash),
+        Err(e) => eprintln!("Failed to generate MD5: {}", e),
+    }
+
+    let sha256 = generate_sha256(&mut file);
+    match sha256 {
+        Ok(hash) => println!("Sha256 Hash is: {}", hash),
+        Err(e) => eprintln!("Failed to generate SHA256: {}", e),
+    }
+}


### PR DESCRIPTION
This adds MD5 and SHA256 support as the initial features.  The CLI usage requires the `-f` flag be passed in with the file name you want to hash.

```
./target/release/hash_gen -f Cargo.toml
File Name: Cargo.toml
MD5 Hash is: 0771d4bc07415869da4fa122f0b81c2c
Sha256 Hash is: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
```