### PR TITLE
Manage hash  algos dynamically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
+digest = "0.10.7"
 md-5 = "0.10.6"
+sha1 = "0.10.6"
 sha2 = "0.10.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use std::fs::File;
-use std::io::{self, Seek, Read};
 use digest::DynDigest;
+use std::fs::File;
+use std::io::{self, Read, Seek};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -42,11 +42,9 @@ fn generate_hash(file: &mut File, hash: &mut Box<dyn DynDigest>) -> io::Result<S
         hash.update(&buffer[..byte_read]);
     }
 
-    let result =  hash.finalize_reset();
+    let result = hash.finalize_reset();
     Ok(bytes_to_hex_string(&result))
 }
-
-
 
 fn main() {
     let args = Args::parse();
@@ -58,7 +56,6 @@ fn main() {
             return;
         }
     };
-
 
     let mut md5: Box<dyn DynDigest> = select_hasher("md5");
     let md5_hash = generate_hash(&mut file, &mut md5).unwrap();


### PR DESCRIPTION
Initially there was a function per has algorithm.  This would create a lot of duplicate code and was unnecessary.  This refactor adds the ability to select a hash algorithm and provide it to the generate_hash function. 